### PR TITLE
Added particles to projects page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -1,5 +1,11 @@
+<div id="particles-js"></div>
+
 <!DOCTYPE html>
 <html lang="en">
+  <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
+  <!-- stats.js lib -->
+  <script src="https://threejs.org/examples/js/libs/stats.min.js"></script>
+  <script src="particles.js"></script>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -34,7 +40,7 @@ span {
 h1 {
     text-align: center;
     font-size: 10vh;
-    font-family: "Comic Sans MS", cursive, sans-serif;   
+    font-family: "Comic Sans MS", cursive, sans-serif;
 }
 
 .footer {
@@ -65,5 +71,56 @@ h1 {
     transform: translate(-100%, 0);
   }
 }
+
+body {
+    margin: 0;
+  }
+  canvas {
+    display: block;
+    vertical-align: bottom;
+  } /* ---- particles.js container ---- */
+  #particles-js {
+    top:0;
+    z-index: -1;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background-color: #ffffff00;
+    background-image: url("");
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: 50% 50%;
+  } /* ---- stats.js ---- */
+  .count-particles {
+    background: #000022;
+    position: absolute;
+    top: 48px;
+    left: 0;
+    width: 80px;
+    color: #13e8e9;
+    font-size: 0.8em;
+    text-align: left;
+    text-indent: 4px;
+    line-height: 14px;
+    padding-bottom: 2px;
+  }
+  .js-count-particles {
+    font-size: 1.1em;
+  }
+  #stats,
+  .count-particles {
+    -webkit-user-select: none;
+    margin-top: 5px;
+    margin-left: 5px;
+  }
+  #stats {
+    border-radius: 3px 3px 0 0;
+    overflow: hidden;
+  }
+  .count-particles {
+    border-radius: 0 0 3px 3px;
+  }
+
+</style>
 
 </style>


### PR DESCRIPTION
Realistically maybe we should use a proper frontend framework so we can load the page contents overtop of the background, and move between pages without all the Ws re-drawing.

But whatever, looks like this now:

![image](https://user-images.githubusercontent.com/16950874/77211318-02c37480-6ada-11ea-90fc-3de2b3ce90c9.png)
